### PR TITLE
Bootstrap Django + DRF com Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# traknor-cmms-backend
+# TrakNor CMMS Backend
+
+Código-fonte do backend. Consulte `backend/README.md` para instruções de execução.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+DEBUG=True
+SECRET_KEY=changeme-in-dev
+DATABASE_URL=postgres://traknor:traknor@db:5432/traknor
+ALLOWED_HOSTS=*

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+# Instala dependências de compilação mínimas
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential libpq-dev && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# Cria usuário não root para executar a aplicação
+RUN adduser --disabled-password --no-create-home appuser
+USER appuser
+
+EXPOSE 8000
+
+CMD ["/app/entrypoint.sh"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,29 @@
+# TrakNor Backend
+
+Este projeto configura uma base em Django com Django REST Framework, executada em contêineres Docker.
+
+## Pré-requisitos
+- Docker
+- Docker Compose
+
+## Configuração rápida
+```bash
+cp .env.example .env
+docker compose build
+docker compose up -d
+```
+
+As migrações são executadas automaticamente na inicialização. Para aplicar manualmente:
+```bash
+docker compose run --rm web python src/manage.py migrate
+```
+
+## Endpoints
+- `GET /health` — verifica o estado da API.
+- `GET /docs` — interface interativa da documentação.
+- `GET /schema` — esquema OpenAPI em JSON.
+
+## Comandos úteis
+- Criar superusuário: `docker compose run --rm web python src/manage.py createsuperuser`
+- Gerar migrações: `docker compose run --rm web python src/manage.py makemigrations`
+```

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: traknor
+      POSTGRES_USER: traknor
+      POSTGRES_PASSWORD: traknor
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      interval: 5s
+      retries: 5
+
+  web:
+    build: .
+    env_file: .env
+    volumes:
+      - ./src:/app/src
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  postgres_data:

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Aguarda o banco de dados ficar disponível antes de iniciar a aplicação.
+set -e
+
+until pg_isready -d "$DATABASE_URL"; do
+  echo "Aguardando o banco de dados..."
+  sleep 1
+done
+
+# Executa migrações pendentes.
+python src/manage.py migrate --noinput
+
+# Inicia o servidor WSGI usando gunicorn.
+exec gunicorn config.wsgi:application --bind 0.0.0.0:8000

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,8 @@
+Django>=5.0,<6.0
+djangorestframework>=3.15
+drf-spectacular>=0.27
+django-filter>=24.2
+django-environ>=0.11
+psycopg2-binary>=2.9
+gunicorn>=22.0
+whitenoise>=6.7

--- a/backend/src/config/__init__.py
+++ b/backend/src/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configurações iniciais do projeto Django."""

--- a/backend/src/config/asgi.py
+++ b/backend/src/config/asgi.py
@@ -1,0 +1,8 @@
+"""ASGI config para o projeto, expõe a aplicação ASGI."""
+
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_asgi_application()

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -1,0 +1,97 @@
+"""Configurações principais do projeto Django."""
+
+from pathlib import Path
+import environ
+
+# Diretórios base do projeto
+BASE_DIR = Path(__file__).resolve().parent.parent  # src
+ROOT_DIR = BASE_DIR.parent  # backend
+
+# Carrega variáveis de ambiente do arquivo .env, se existir
+env = environ.Env(
+    DEBUG=(bool, False),
+)
+if (ROOT_DIR / ".env").exists():
+    environ.Env.read_env(ROOT_DIR / ".env")
+
+SECRET_KEY = env("SECRET_KEY", default="")
+DEBUG = env.bool("DEBUG", default=False)
+ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["*"])
+
+# Configurações do banco de dados utilizando DATABASE_URL
+DATABASES = {
+    "default": env.db_url("DATABASE_URL", default="sqlite:///db.sqlite3")
+}
+
+# Aplicativos instalados
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "rest_framework",
+    "drf_spectacular",
+    "django_filters",
+    "core",
+]
+
+# Middlewares padrão e WhiteNoise para servir estáticos
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "config.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    }
+]
+
+WSGI_APPLICATION = "config.wsgi.application"
+
+# Configurações do DRF
+REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
+    "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
+}
+
+# Configurações do drf-spectacular
+SPECTACULAR_SETTINGS = {
+    "TITLE": "TrakNor API",
+    "VERSION": "0.1.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+}
+
+# Configurações de arquivos estáticos
+STATIC_URL = "/static/"
+STATIC_ROOT = ROOT_DIR / "staticfiles"
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+# Localização
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "America/Sao_Paulo"
+USE_I18N = True
+USE_TZ = True
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/backend/src/config/urls.py
+++ b/backend/src/config/urls.py
@@ -1,0 +1,12 @@
+"""Mapeamento de URLs da aplicação."""
+
+from django.contrib import admin
+from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+
+urlpatterns = [
+    path("", include("core.urls")),
+    path("schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="docs"),
+    path("admin/", admin.site.urls),
+]

--- a/backend/src/config/wsgi.py
+++ b/backend/src/config/wsgi.py
@@ -1,0 +1,8 @@
+"""WSGI config para o projeto, expõe a aplicação WSGI."""
+
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_wsgi_application()

--- a/backend/src/core/__init__.py
+++ b/backend/src/core/__init__.py
@@ -1,0 +1,1 @@
+"""Aplicativo principal contendo utilidades básicas."""

--- a/backend/src/core/apps.py
+++ b/backend/src/core/apps.py
@@ -1,0 +1,10 @@
+"""Configuração da aplicação core."""
+
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    """Configurações da app core."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "core"

--- a/backend/src/core/tests/test_health.py
+++ b/backend/src/core/tests/test_health.py
@@ -1,0 +1,13 @@
+"""Testes para o endpoint de saúde."""
+
+from django.test import TestCase
+
+
+class HealthCheckTests(TestCase):
+    """Verifica se o endpoint /health responde corretamente."""
+
+    def test_health_endpoint_returns_ok(self):
+        """Deve retornar HTTP 200 com o JSON esperado."""
+        response = self.client.get("/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})

--- a/backend/src/core/urls.py
+++ b/backend/src/core/urls.py
@@ -1,0 +1,8 @@
+"""URLs expostas pela aplicação core."""
+
+from django.urls import path
+from .views import HealthCheckView
+
+urlpatterns = [
+    path("health", HealthCheckView.as_view(), name="health"),
+]

--- a/backend/src/core/views.py
+++ b/backend/src/core/views.py
@@ -1,0 +1,13 @@
+"""Views básicas da aplicação."""
+
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework import status
+
+
+class HealthCheckView(APIView):
+    """Retorna o status de saúde da API."""
+
+    def get(self, request):
+        """Responde com um simples JSON indicando que a API está funcionando."""
+        return Response({"status": "ok"}, status=status.HTTP_200_OK)

--- a/backend/src/manage.py
+++ b/backend/src/manage.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+"""Ponto de entrada para comandos administrativos do Django."""
+import os
+import sys
+
+def main() -> None:
+    """Executa tarefas administrativas."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Descrição
- Estrutura inicial do projeto Django 5 com DRF e configuração via Docker
- Endpoint de saúde e documentação automática com drf-spectacular

## Critérios de aceite
- `GET /health` retorna 200 com `{ "status": "ok" }`
- `GET /docs` exibe a documentação gerada
- Migrações executadas na inicialização do contêiner web
- `python src/manage.py check` sem erros

## Dependências
- Docker e Docker Compose para executar a aplicação

Labels: backend, api, drf, infra, docs, tests

