### PR TITLE
feat: endpoint de perfil do usuário

### DIFF
--- a/accounts/api.py
+++ b/accounts/api.py
@@ -1,0 +1,18 @@
+"""Views relacionadas a contas de usuário."""
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .serializers import MeSerializer
+
+
+class MeView(APIView):
+    """Retorna o perfil do usuário autenticado."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        """Responde com os dados do próprio usuário."""
+        serializer = MeSerializer(request.user, context={"request": request})
+        return Response({"data": serializer.data})

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from rest_framework import serializers
+
+from accounts.services import get_user_role
+
+User = get_user_model()
+
+
+class MeSerializer(serializers.ModelSerializer):
+    """Serializador para retornar os dados do próprio usuário.
+
+    Comentários explicativos em PT-BR conforme instruções.
+    """
+
+    role = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "username",
+            "email",
+            "first_name",
+            "last_name",
+            "role",
+        ]
+
+    def get_role(self, obj: User) -> str | None:
+        """Obtém o papel do usuário no tenant atual."""
+        request = self.context.get("request")
+        if not request:
+            return None
+        tenant = getattr(request, "tenant", None)
+        if not tenant:
+            return None
+        role = get_user_role(obj, tenant)
+        return role.value if role else None

--- a/tests/api/test_users_me.py
+++ b/tests/api/test_users_me.py
@@ -1,0 +1,52 @@
+import pytest
+from django_tenants.utils import schema_context
+from django.contrib.auth import get_user_model
+
+from tenancy.models import Tenant, Domain
+from accounts.models import Membership
+from accounts.roles import Role
+
+
+@pytest.fixture
+def tenant(db):
+    """Cria um tenant simples para os testes."""
+    tenant = Tenant(schema_name="acme", name="ACME Ltd.")
+    tenant.save()
+    Domain.objects.create(domain="acme.localhost", tenant=tenant, is_primary=True)
+    return tenant
+
+
+@pytest.fixture
+def user(tenant):
+    """Cria um usuário associado ao tenant."""
+    User = get_user_model()
+    with schema_context(tenant.schema_name):
+        user = User.objects.create_user(
+            username="john",
+            email="john@example.com",
+            password="senha123",
+            first_name="John",
+            last_name="Doe",
+        )
+        Membership.objects.create(
+            user=user, tenant=tenant, role=Role.TECHNICIAN.value
+        )
+    return user
+
+
+@pytest.mark.django_db
+def test_me_endpoint_returns_user_data(client, tenant, user):
+    """Verifica se o endpoint retorna os dados do usuário autenticado."""
+    client.force_login(user)
+    resp = client.get("/users/me", HTTP_HOST="acme.localhost")
+    assert resp.status_code == 200
+    body = resp.json()["data"]
+    assert body["email"] == "john@example.com"
+    assert body["role"] == Role.TECHNICIAN.value
+
+
+@pytest.mark.django_db
+def test_me_endpoint_requires_authentication(client, tenant):
+    """Requisições sem autenticação devem retornar 401."""
+    resp = client.get("/users/me", HTTP_HOST="acme.localhost")
+    assert resp.status_code == 401

--- a/traknor/urls.py
+++ b/traknor/urls.py
@@ -22,6 +22,7 @@ from rest_framework.routers import SimpleRouter
 from .views import LoginView, health, trigger_error
 from sample.api import ExampleViewSet
 from django.conf import settings
+from accounts.api import MeView
 
 router = SimpleRouter()
 router.register("_example", ExampleViewSet, basename="example")
@@ -36,6 +37,7 @@ urlpatterns = [
     path("health", health, name="health"),
     path("_error", trigger_error, name="_error"),
     path("auth/login", LoginView.as_view(), name="auth-login"),
+    path("users/me", MeView.as_view(), name="users-me"),
 ]
 
 urlpatterns += router.urls


### PR DESCRIPTION
## Título
feat: endpoint de perfil do usuário

## Descrição
- adiciona serializer e view para `/users/me`
- expõe rota `users/me` retornando dados do usuário autenticado
- inclui testes básicos para o endpoint

## Critérios de aceite
- [ ] `GET /users/me` retorna 200 com os dados do usuário autenticado
- [ ] `GET /users/me` retorna 401 sem autenticação

## Dependências
- nenhuma

## Labels
backend, api, drf, tenant, tests
